### PR TITLE
Remove password.reset.token.reset

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -91,6 +91,7 @@ A space-separated token string of data the reset mechanism responds with (usuall
 - url: a URL (possibly linked) to the page to reset the password.
 - link: A link (without the URL visible) to reset the password.
 - token: A token that can be typed on a page (may also be part of a link/URL) to bring you to the reset screen.
+- temp: A temporary password to use for logging in.
 
 ## password.reset.token.expires
 
@@ -110,11 +111,7 @@ Whether the reset token works as login credentials. Valid values:
 - "after" (the token logs you in after resetting the password)
 - "no" (the token does not log you in)
 
-## password.reset.token.reset
-
-In the rare case that a site's password reset mechanism is something like a temporary password, this value denotes whether you are then *required* to reset the password. Valid values:
-
-- "enforced" (you must reset the password before you can do anything else)
+For sites that use a temporary password as the reset token, a value of "before" implies you may opt not to reset the password (using the password logs you in and you can navigate away), while a value of "after" implies you are *required* to reset the password.
 
 ## password.change.url
 

--- a/profiles/org/wikimedia.yaml
+++ b/profiles/org/wikimedia.yaml
@@ -7,8 +7,7 @@ password:
       body: temp
     token:
       expires: 7d
-      login: yes
-      reset: enforced
+      login: after
   change:
     url: https://commons.wikimedia.org/wiki/Special:ChangePassword
 https: optional


### PR DESCRIPTION
This was only documented as a concession to descriptiveness over prescriptiveness, in the face of me wanting to get every field documented when implementing the fields-must-be-documented test, without having to take time to rethink the structure of any existing, undocumented profile data (I was out to dinner, we'd just paid the check, and we had a bus to catch). It was only ever used to describe Wikimedia (or MediaWiki)'s password reset behavior, and a properly-demarcated password.reset.token.login value communicates that effect just as accurately.