### PR TITLE
Remove bogus registration link from AV Club profile

### DIFF
--- a/profiles/avclub.com.yaml
+++ b/profiles/avclub.com.yaml
@@ -8,8 +8,6 @@ password:
     accept: email
   change:
     url: http://www.avclub.com/users/me/settings/
-register:
-  url: http://www.avclub.com/article/full-trailer-lifetimes-deadly-adoption-cranks-melo-220886
 login:
   url: http://www.avclub.com/login/
 reviewed:


### PR DESCRIPTION
I don't know what the page is to make an account (if there even is one), but it's certainly not the one I had written down.