### PR TITLE
Document "others" as a valid value for password.reset.sessions.invalidate

### DIFF
--- a/docs/fields.md
+++ b/docs/fields.md
@@ -174,6 +174,7 @@ Whether resetting your password invalidates sessions (logs you out), forcing you
 Values:
 
 - "all": demonstrably invalidates all sessions
+- "others": invalidates all sessions other than the one used to reset the password
 - "no": doesn't invalidate any logged-in sessions
   - Although this is less secure than the alternative(s), it's assumed to be the default.
 


### PR DESCRIPTION
Of course, if the user is logged in after resetting a password, they're likely being assigned a new session, but putting "all" for that case just seems inaccurate (see the profile for 37signals.com).